### PR TITLE
Updating docs for tasks without prepayment

### DIFF
--- a/guides/submitting-task/smart-contract.md
+++ b/guides/submitting-task/smart-contract.md
@@ -53,3 +53,24 @@ contract Counter is OpsReady {
     }
 }
 ```
+
+When creating a task where payment is [deferred to execution time](../fee-payment-options.md#transaction-pays-for-itself) use `createTaskNoPrepayment` instead of `createTask`
+
+```solidity
+/// @notice Create a task that tells Gelato to monitor and execute transactions on specific contracts
+/// @dev Requires no funds to be added in Task Treasury, assumes tasks sends fee to Gelato directly
+/// @param _execAddress On which contract should Gelato execute the transactions
+/// @param _execSelector Which function Gelato should eecute on the _execAddress
+/// @param _resolverAddress On which contract should Gelato check when to execute the tx
+/// @param _resolverData Which data should be used to check on the Resolver when to execute the tx
+/// @param _feeToken Which token to use as fee payment
+function createTaskNoPrepayment(
+    address _execAddress,
+    bytes4 _execSelector,
+    address _resolverAddress,
+    bytes calldata _resolverData,
+    address _feeToken
+) public returns (bytes32 task)
+```
+
+


### PR DESCRIPTION
Documenting the use of `createTaskNoPrepayment` when creating tasks that pay for themselves during execution. It wasn't clear this function existed until diving into the codebase